### PR TITLE
resets players code editor in new new

### DIFF
--- a/app/javascript/controllers/game_subscription_controller.js
+++ b/app/javascript/controllers/game_subscription_controller.js
@@ -267,6 +267,12 @@ export default class extends Controller {
 
   disconnect() {
     this.channel.unsubscribe()
+    console.log(this.playerTwoIdValue)
+    if (this.playerTwoIdValue === 1) {
+      let playerOnesForm = new FormData()
+      playerOnesForm.append("game[player_one_id]", 1)
+      this.patchForm(playerOnesForm)
+    }
     WebSocket.CLOSED()
   }
 }


### PR DESCRIPTION
Fixed issue with code being in the code editor when new round starts,
Fixed issue when you leave a game the game doesn't reset to id 1 for both players.